### PR TITLE
fix debounce, add provision to add conf directives, add container ID override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 docker-proxy
 ============
 
-Docker proxy is a reverse proxy for Docker containers that allows the load balancing of multiple sites. It's not a unique idea - there are many clones, but I found myself wanting a few things from the majority that I saw:
+The Docker Proxy project consists of a few components. The end goal is to create a system for reverse proxying containers automatically as they are created and destroyed, allowing the end user to map a single endpoint to multiple containers. The project was created with Docker 1.10 in mind, meaning it supports overlay networks as a first class citizen. The first iteration currently does this using nginx, but a haproxy backend may also be in the works in the future.
 
-* More introspection into the current websites and containers
-* Prodcution stability
-* More flexible virtual host configuration
+The concept, as well as the environment variables to direct it, was taken from [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy). Unfortunately, I found that I wanted a few things that it did not provide:
 
-Many of the ideas were taken from [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy), which is the leading project. Unfortunately, there were many edge cases and bugs when I attempted to use it, and I did not have the level of introspection that I wanted.
+* More introspection into the current websites and containers that are mapped
+* Production stability
+* The ability to watch multiple Docker engines for change, which is very useful in a Swarm environment where the manager does not always report events. 
 
 The project is currently a work in progress, but PRs are always welcome, as well as Issues/Feature Requests.
 

--- a/mapping.go
+++ b/mapping.go
@@ -159,6 +159,10 @@ func myInfo(client *docker.Client) ([]string, string, error) {
 }
 
 func currentContainerID() (string, error) {
+	if id, ok := os.LookupEnv("CONTAINER_ID"); ok {
+		return id, nil
+	}
+
 	file, err := os.Open("/proc/self/cgroup")
 	if err != nil {
 		return "", err

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -1,0 +1,15 @@
+package nginx
+
+var m = map[string]string{
+	"NGINX_CLIENT_MAX_BODY_SIZE": "client_max_body_size",
+}
+
+func envToDirectives(env map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range m {
+		if val, ok := env[k]; ok {
+			out[v] = val
+		}
+	}
+	return out
+}

--- a/nginx/template.go
+++ b/nginx/template.go
@@ -74,6 +74,7 @@ server {
 	ssl_certificate {{ .SSLPrefix }}.crt;
 	ssl_certificate_key {{ .SSLPrefix }}.key;
 	add_header Strict-Transport-Security "max-age=31536000";
+	{{ template "config" .Config }}
 	location / {
 		proxy_pass http://{{ .ID }};
 	}
@@ -84,8 +85,11 @@ var nginxNoSSL = `
 server {
 	server_name {{ .Host }};
 	listen 80;
+	{{ template "config" .Config }}
 	location / {
 		proxy_pass http://{{ .ID }};
 	}
 }
 `
+
+var nginxOptions = `{{ define "config" }}{{ range $key, $value := . }}{{ $key }} {{ $value }};{{ end }} {{ end }}`

--- a/updater.go
+++ b/updater.go
@@ -69,10 +69,15 @@ func debounceChannel(interval time.Duration, input chan struct{}) chan struct{} 
 				close(output)
 				return
 			}
-			select {
-			case <-input:
-			case <-time.After(interval):
-				output <- struct{}{}
+		Triggered:
+			for {
+				select {
+				case <-input:
+				case <-time.After(interval):
+					log.Info("debounce triggered, updating")
+					output <- struct{}{}
+					break Triggered
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Does what it says on the tin:
- Fixes the debounce to do what it should. Previously if there were an odd number of things sent to debounce before it triggered, it would stay that way until the next call. 
- NGINX proxy will now generate a map of additional config directives per container from the container's environment. Only supports upping the POST body size for now, but adding more is trivial. 
- The method that fetches the container we are currently on now allows for override, which makes testing it on a local machine pointed at a Docker instance possible.
